### PR TITLE
Fixed bug connected with float arythmethic

### DIFF
--- a/src/v1.8/v1.8.7/nex-ac.inc
+++ b/src/v1.8/v1.8.7/nex-ac.inc
@@ -1157,7 +1157,7 @@ ac_fpublic: ac_SetPlayerSpecialAction(playerid, actionid)
 
 ac_fpublic: ac_SetPlayerInterior(playerid, interiorid)
 {
-	while(interiorid < 0) interiorid += 256;
+	if(interiorid < 0) interiorid %= 256;
 	if(interiorid != GetPlayerInterior(playerid))
 	{
 		AntiCheatInfo[playerid][acNOPCount][2] = 0;
@@ -3113,8 +3113,7 @@ stock acc_RepairVehicle(vehicleid)
 						}
 						static Float:ac_zangle;
 						GetVehicleZAngle(ac_vehid, ac_zangle);
-						while(ac_zangle < 0.0) ac_zangle += 360.0;
-						while(ac_zangle > 360.0) ac_zangle -= 360.0;
+						ac_zangle = floatround(ac_zangle, floatround_floor) % 360 + floatfract(ac_zangle);
 						GetVehicleVelocity(ac_vehid, ac_pvelX, ac_pvelY, ac_pvelZ);
 						if(ac_gtc > AntiCheatInfo[playerid][acGtc][9] + ac_gpp)
 						{


### PR DESCRIPTION
In this code don't have to use while loop. You can use a modulo operation.
Also, this code can provide a infinite loop. As example:
new Float:f = -20000000000.0;
while(f < 0.0) f+=360.0;
Will give as a result an infinite loop, because of single-precision floating point arithmetic. (This bug is also in floats in C)
I don't know how, but someone used this bug (variable ac_zangle), and my whole server hangs up.