### PR TITLE
Adaptation for train wagon entry

### DIFF
--- a/src/v1.9/v1.9.23/r2/nex-ac.inc
+++ b/src/v1.9/v1.9.23/r2/nex-ac.inc
@@ -4335,16 +4335,19 @@ static stock fs_AntiCheatSetNextDialog(playerid, dialogid)
 							{
 								if(ac_vX < 3.0 && ac_vctsize > 5.0)
 								{
-									if(ACInfo[playerid][acACAllow][2])
+									if(GetVehicleModel(ACInfo[playerid][acEnterVeh]) != 570 || ac_vctsize > 9.0)
 									{
-										#if defined DEBUG
-											printf("[Nex-AC debug] Speed: %.1f, distance: %f", ac_vX, ac_vctsize);
-										#endif
-										#if defined OnCheatDetected
-											ac_KickWithCode(playerid, "", 0, 2, 3);
-										#else
-											return ac_KickWithCode(playerid, "", 0, 2, 3);
-										#endif
+										if(ACInfo[playerid][acACAllow][2])
+										{
+											#if defined DEBUG
+												printf("[Nex-AC debug] Speed: %.1f, distance: %f", ac_vX, ac_vctsize);
+											#endif
+											#if defined OnCheatDetected
+												ac_KickWithCode(playerid, "", 0, 2, 3);
+											#else
+												return ac_KickWithCode(playerid, "", 0, 2, 3);
+											#endif
+										}
 									}
 								}
 								else if(ACInfo[playerid][acACAllow][0] && ac_vX &&

--- a/src/v1.9/v1.9.23/r2/nex-ac.inc
+++ b/src/v1.9/v1.9.23/r2/nex-ac.inc
@@ -3845,7 +3845,8 @@ static stock fs_AntiCheatSetNextDialog(playerid, dialogid)
 					if(ACInfo[playerid][acVeh] == 0)
 					{
 						if(ACInfo[playerid][acACAllow][4] &&
-						(ACInfo[playerid][acEnterVeh] != ac_vehid || ac_gtc < ACInfo[playerid][acEnterVehTime] + 600))
+						(ACInfo[playerid][acEnterVeh] != ac_vehid || ac_gtc < ACInfo[playerid][acEnterVehTime] + 600) &&
+						GetVehicleModel(ACInfo[playerid][acEnterVeh]) != 570)
 						{
 							#if defined DEBUG
 								printf("[Nex-AC debug] Entered vehicle: %d, vehicleid: %d, Enter time: %d",

--- a/src/v1.9/v1.9.23/r2/nex-ac.inc
+++ b/src/v1.9/v1.9.23/r2/nex-ac.inc
@@ -4335,9 +4335,9 @@ static stock fs_AntiCheatSetNextDialog(playerid, dialogid)
 							{
 								if(ac_vX < 3.0 && ac_vctsize > 5.0)
 								{
-									if(GetVehicleModel(ACInfo[playerid][acEnterVeh]) != 570 || ac_vctsize > 9.0)
+									if(ACInfo[playerid][acACAllow][2])
 									{
-										if(ACInfo[playerid][acACAllow][2])
+										if(GetVehicleModel(ACInfo[playerid][acEnterVeh]) != 570 || ac_vctsize > 9.0)
 										{
 											#if defined DEBUG
 												printf("[Nex-AC debug] Speed: %.1f, distance: %f", ac_vX, ac_vctsize);


### PR DESCRIPTION
The passenger train wagon have different behavior for entry and that caused problems because the players gets teleported directly into the wagons then they press G.