### PR TITLE
Fixed the include path for pawn.json

### DIFF
--- a/pawn.json
+++ b/pawn.json
@@ -1,5 +1,5 @@
 {
 	"user": "NexiusTailer",
 	"repo": "Nex-AC",
-	"entry": "src/v1.9.52/nex-ac.inc"
+	"include_path": "src/v1.9.52"
 }


### PR DESCRIPTION
Due to the file being in a sub folder, it was not easily accessible. To fix that you instead use `include_path` to define the path of the sub folders that the include belongs in.