### PR TITLE
'acTimerTick' Should use real tick count

### DIFF
--- a/src/v1.9.53/nex-ac.inc
+++ b/src/v1.9.53/nex-ac.inc
@@ -8796,8 +8796,8 @@ ac_fpublic ac_Timer(playerid)
 	}
 	if(ACInfo[playerid][acKicked] < 1)
 	{
-		ACInfo[playerid][acTimerTick] = ac_gtc;
 		ACInfo[playerid][acTimerID] = SetTimerEx("ac_Timer", 1000, false, "i", playerid);
+		ACInfo[playerid][acTimerTick] = GetTickCount();
 	}
 	return 1;
 }


### PR DESCRIPTION
'acTimerTick' Should use actual tick count from the moment the timer is called.
Will help with stability during server lag.