### PR TITLE
Update pawn.json

### DIFF
--- a/pawn.json
+++ b/pawn.json
@@ -2,6 +2,7 @@
 	"user": "NexiusTailer",
 	"repo": "Nex-AC",
 	"include_path": "src/v1.9.55",
+	"dependencies": ["sampctl/samp-stdlib"],
 	"build":
 	{
 		"compiler":


### PR DESCRIPTION
Small fix in pawn.json
Without deps in pawn.json file, u can't uninstall package by sampctl, because u will get this error:
"ERROR: failed to parse Nex-AC as a dependency string: dependency string does not match pattern"