### PR TITLE
compatibility with old folder

### DIFF
--- a/src/v1.9.56/nex-ac.inc
+++ b/src/v1.9.56/nex-ac.inc
@@ -23,7 +23,7 @@
 #endif
 
 #if !defined _nex_ac_lang_included
-	#include <nex-ac_en.lang>	//Localization
+	#include "../include/nex-ac_en.lang"	//Localization
 #endif
 
 #define	NEX_AC_VERSION				"1.9.56"


### PR DESCRIPTION
the language does not load when using sa-mp's default include folder, which is in the main directory. 
That way it works for everyone.