### PR TITLE
fix missing constant

### DIFF
--- a/src/v1.9.64/nex-ac.inc
+++ b/src/v1.9.64/nex-ac.inc
@@ -9453,7 +9453,7 @@ ac_fpublic ac_Timer(playerid)
 #if !defined OnCheatDetected
 	//Don't make changes in this public
 	//To customize punishments, declare 'OnCheatDetected' in your script
-	ac_fpublic ac_OnCheatDetected(playerid, ip_address[], type, code)
+	ac_fpublic ac_OnCheatDetected(playerid, const ip_address[], type, code)
 	{
 		if(type)
 		{
@@ -9923,7 +9923,7 @@ static ac_FloodDetect(playerid, publicid)
 	return 0;
 }
 
-static ac_KickWithCode(playerid, ip_address[], type, code, code2 = 0)
+static ac_KickWithCode(playerid, const ip_address[], type, code, code2 = 0)
 {
 	if(type == 0 && (!IsPlayerConnected(playerid) || ACInfo[playerid][acKicked] > 0)) return 0;
 	#if AC_USE_STATISTICS


### PR DESCRIPTION
Have issue with compiler 3.10.10 that had a warning because missing constant on parameter  `ac_OnCheatDetected` and `ac_KickWithCode`